### PR TITLE
fix: correct clone URL, remove stale ngrok ref, align explorer URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ Modern multi-chain treasury management system. This sample application uses Next
 1. Clone the repository and install dependencies:
 
    ```bash
-   git clone git@github.com:akelani-circle/fintech-starter.git
-   cd fintech-starter
+   git clone git@github.com:circlefin/arc-fintech.git
+   cd arc-fintech
    npm install
    ```
 
@@ -34,7 +34,6 @@ Modern multi-chain treasury management system. This sample application uses Next
    ```bash
    cp .env.example .env.local
    ```
-   Replace `your-ngrok-url` with your actual ngrok forwarding URL from step 4.
 
    Then edit `.env.local` and fill in all required values (see [Environment Variables](#environment-variables) section below).
 

--- a/lib/circle/gateway-sdk.ts
+++ b/lib/circle/gateway-sdk.ts
@@ -49,7 +49,7 @@ export const arcTestnet = {
     default: { http: [`https://rpc.testnet.arc.network/${arcRpcKey}`] },
   },
   blockExplorers: {
-    default: { name: 'Explorer', url: 'https://explorer.arc.testnet.circle.com' },
+    default: { name: 'Explorer', url: 'https://testnet.arcscan.app' },
   },
   testnet: true,
 } as const satisfies Chain;


### PR DESCRIPTION
## Summary

- **README**: Update clone URL from `akelani-circle/fintech-starter` to `circlefin/arc-fintech` and the `cd` directory accordingly
- **README**: Remove the dangling "Replace your-ngrok-url … from step 4" instruction — step 4 is "Start the development server" and no ngrok step exists
- **gateway-sdk.ts**: Replace `explorer.arc.testnet.circle.com` (connection refused) with `testnet.arcscan.app` to match `block-explorers.ts`

## Verification

- `https://testnet.arcscan.app` — resolves (Blockscout-based Arc Testnet explorer)
- `https://explorer.arc.testnet.circle.com` — ECONNREFUSED
- `block-explorers.ts` already uses `testnet.arcscan.app` for `ARC-TESTNET`