### PR TITLE
docs(readme): fix incorrect git clone URL in Getting Started

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ Modern multi-chain treasury management system. This sample application uses Next
 1. Clone the repository and install dependencies:
 
    ```bash
-   git clone git@github.com:akelani-circle/fintech-starter.git
-   cd fintech-starter
+   git clone git@github.com:circlefin/arc-fintech.git
+   cd arc-fintech
    npm install
    ```
 


### PR DESCRIPTION
The current README has the git clone URL pointing to a personal repo that isn't publicly accessible:

\`\`\`
git clone git@github.com:akelani-circle/fintech-starter.git
cd fintech-starter
\`\`\`

This causes step 1 of "Getting Started" to fail for new contributors — \`akelani-circle/fintech-starter\` isn't reachable, and even if it were, the directory name (\`fintech-starter\`) doesn't match the canonical repo name (\`arc-fintech\`).

Updated to point to the canonical public location:

\`\`\`
git clone git@github.com:circlefin/arc-fintech.git
cd arc-fintech
\`\`\`

Same trivial fix applies to \`arc-escrow\` and \`arc-p2p-payments\` (filing separate PRs for those).