### PR TITLE
fix(arc-testnet): native USDC has 18 decimals, fix broken explorer URL

### DIFF
--- a/lib/circle/gateway-sdk.ts
+++ b/lib/circle/gateway-sdk.ts
@@ -44,12 +44,12 @@ const arcRpcKey = process.env.ARC_TESTNET_RPC_KEY || 'c0ca2582063a5bbd5db2f98c13
 export const arcTestnet = {
   id: 5042002,
   name: 'Arc Testnet',
-  nativeCurrency: { name: 'USD Coin', symbol: 'USDC', decimals: 6 },
+  nativeCurrency: { name: 'USDC', symbol: 'USDC', decimals: 18 },
   rpcUrls: {
     default: { http: [`https://rpc.testnet.arc.network/${arcRpcKey}`] },
   },
   blockExplorers: {
-    default: { name: 'Explorer', url: 'https://explorer.arc.testnet.circle.com' },
+    default: { name: 'Arcscan', url: 'https://testnet.arcscan.app' },
   },
   testnet: true,
 } as const satisfies Chain;


### PR DESCRIPTION
Two real chain-configuration bugs in \`lib/circle/gateway-sdk.ts\` that propagate into any fork using this sample as a template.

### 1. Wrong native decimals

\`\`\`diff
- nativeCurrency: { name: 'USD Coin', symbol: 'USDC', decimals: 6 },
+ nativeCurrency: { name: 'USDC', symbol: 'USDC', decimals: 18 },
\`\`\`

Arc's native gas token uses **18 decimals** (like ETH on other EVM chains), not 6. ERC-20 USDC at \`0x3600...\` has 6 decimals as a view, but the chain-level \`nativeCurrency.decimals\` in a viem/wagmi \`Chain\` definition refers to native gas, which is 18 on Arc. Quoted from [\`circlefin/skills/use-arc/SKILL.md\`](https://github.com/circlefin/skills/blob/master/plugins/circle/skills/use-arc/SKILL.md):

> "Dual decimals: Native gas uses 18 decimals (like ETH on other chains). ERC-20 USDC uses 6 decimals. Mixing these up will produce incorrect amounts."

Empirical confirmation: \`circlefin/arc-commerce/lib/wagmi/config.ts\` correctly uses \`decimals: 18\`. The current value of 6 causes any \`formatEther\`/\`formatUnits\` against this \`nativeCurrency\` to be off by a factor of \`10^12\`.

### 2. Broken block explorer URL

\`\`\`diff
- default: { name: 'Explorer', url: 'https://explorer.arc.testnet.circle.com' },
+ default: { name: 'Arcscan', url: 'https://testnet.arcscan.app' },
\`\`\`

\`explorer.arc.testnet.circle.com\` returns HTTP 000 (DNS does not resolve):

\`\`\`bash
$ curl -sI -o /dev/null -w "%{http_code}\n" "https://explorer.arc.testnet.circle.com"
000
$ curl -sI -o /dev/null -w "%{http_code}\n" "https://testnet.arcscan.app"
200
\`\`\`

\`testnet.arcscan.app\` is the canonical Arc Testnet explorer (referenced in \`circlefin/skills/use-arc/SKILL.md\`, this repo's own \`lib/constants/block-explorers.ts\`, and \`circlefin/arc-commerce\`). Any "View on Explorer" link built from this chain config currently 404s.

---

Companion PR with the same fixes plus a third (wrong native token symbol "ARC") for \`arc-multichain-wallet\`: [circlefin/arc-multichain-wallet#37](https://github.com/circlefin/arc-multichain-wallet/pull/37).