### PR TITLE
fix(arc-testnet): correct nativeCurrency decimals from 6 to 18

### DIFF
--- a/lib/circle/gateway-sdk.ts
+++ b/lib/circle/gateway-sdk.ts
@@ -44,7 +44,7 @@ const arcRpcKey = process.env.ARC_TESTNET_RPC_KEY || 'c0ca2582063a5bbd5db2f98c13
 export const arcTestnet = {
   id: 5042002,
   name: 'Arc Testnet',
-  nativeCurrency: { name: 'USD Coin', symbol: 'USDC', decimals: 6 },
+  nativeCurrency: { name: 'USDC', symbol: 'USDC', decimals: 18 },
   rpcUrls: {
     default: { http: [`https://rpc.testnet.arc.network/${arcRpcKey}`] },
   },


### PR DESCRIPTION
## Summary

`lib/circle/gateway-sdk.ts:47` defines Arc Testnet's native currency as:

```typescript
nativeCurrency: { name: 'USD Coin', symbol: 'USDC', decimals: 6 }
```

However, Arc Testnet uses USDC as native gas with **18 decimals**, while ERC-20 USDC uses 6. Because viem's chain config treats `nativeCurrency.decimals` as the value used for `formatEther` / `formatUnits` defaults and balance calculations, balances displayed via this chain config will be off by 10^12.

## Verification

The same chain config pattern was identified and corrected in [`arc-multichain-wallet#37`](https://github.com/circlefin/arc-multichain-wallet/pull/37) by @Ccheh, where the same fix was applied alongside additional corrections.

## Change

```diff
-  nativeCurrency: { name: 'USD Coin', symbol: 'USDC', decimals: 6 },
+  nativeCurrency: { name: 'USDC', symbol: 'USDC', decimals: 18 },
```

The `name` field was also updated from `'USD Coin'` to `'USDC'` for consistency with the `symbol` field (matching the change made in arc-multichain-wallet#37).

## Notes

- Single-line change (1 file, +1/-1).
- This PR is independent of [#9](https://github.com/circlefin/arc-fintech/pull/9) by @skyc1e, which addresses the explorer URL inconsistency on a different line in the same file.
- The chain config appears to be copied across sample apps; same fix should be checked in any other apps using this template.