### PR TITLE
fix: require authentication before wallet and wallet-set creation

### DIFF
--- a/app/api/wallet-set/route.ts
+++ b/app/api/wallet-set/route.ts
@@ -18,9 +18,19 @@
 
 import { NextRequest, NextResponse } from "next/server";
 import { circleDeveloperSdk } from "@/lib/circle/developer-controlled-wallets-client";
+import { createClient } from "@/lib/supabase/server";
 
 export async function POST(req: NextRequest) {
   try {
+    const supabase = await createClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+
+    if (!user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
     const { entityName } = await req.json();
 
     if (!entityName.trim()) {

--- a/app/api/wallet/route.ts
+++ b/app/api/wallet/route.ts
@@ -33,6 +33,15 @@ const DB_CHAIN_TO_SDK: Record<string, SupportedChain> = {
 
 export async function POST(req: NextRequest) {
   try {
+    const supabase = await createClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+
+    if (!user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
     const { walletSetId, blockchain } = await req.json();
 
     if (!walletSetId || !blockchain) {
@@ -63,31 +72,24 @@ export async function POST(req: NextRequest) {
 
     // After creating the wallet, register the gateway signer
     try {
-      const supabase = await createClient();
-      const {
-        data: { user },
-      } = await supabase.auth.getUser();
+      const { data: eoaWallet } = await supabase
+        .from("wallets")
+        .select("address")
+        .eq("user_id", user.id)
+        .eq("blockchain", blockchain)
+        .eq("type", "gateway_signer")
+        .single();
 
-      if (user) {
-        const { data: eoaWallet } = await supabase
-          .from("wallets")
-          .select("address")
-          .eq("user_id", user.id)
-          .eq("blockchain", blockchain)
-          .eq("type", "gateway_signer")
-          .single();
-
-        if (eoaWallet) {
-          console.log(
-            `Will add EOA delegate ${eoaWallet.address} for depositor ${response.data.wallets[0].address}`
-          );
-          await initiateDepositFromCustodialWallet(
-            response.data.wallets[0].id as string,
-            DB_CHAIN_TO_SDK[blockchain],
-            BigInt(0),
-            eoaWallet.address as any
-          );
-        }
+      if (eoaWallet) {
+        console.log(
+          `Will add EOA delegate ${eoaWallet.address} for depositor ${response.data.wallets[0].address}`
+        );
+        await initiateDepositFromCustodialWallet(
+          response.data.wallets[0].id as string,
+          DB_CHAIN_TO_SDK[blockchain],
+          BigInt(0),
+          eoaWallet.address as any
+        );
       }
     } catch (error) {
       console.error("Failed to register delegate for gateway:", error);


### PR DESCRIPTION
## Problem

Two endpoints either skip authentication entirely or run privileged Circle SDK calls before the auth check, allowing unauthenticated callers to abuse the app's Circle developer account.

### `app/api/wallet-set/route.ts` (POST)
The handler has no Supabase import and no `getUser()` call at all. Any unauthenticated HTTP client can create wallet sets in the app's Circle developer account.

### `app/api/wallet/route.ts` (POST)
`circleDeveloperSdk.createWallets()` is called at line ~46, **before** the only auth check at line ~66. The auth check also lives inside an inner `try/catch` explicitly labeled "do not block wallet creation if this fails," so even a failure there doesn't gate the SDK call.

### Impact
- **Quota abuse:** Each unauthenticated call burns Circle API quota.
- **Resource pollution:** Orphaned wallets and wallet sets accumulate in the developer account.
- **Inconsistency:** Every other route in the codebase (`transfer`, `payout`, `deposit`, `compliance`) correctly calls `supabase.auth.getUser()` at the top and returns 401 before touching any external API. These two are the outliers.

## Fix

Move the auth check to the top of each handler, matching the existing pattern used by `app/api/wallet/transfer/route.ts` and `app/api/gateway/deposit/route.ts`:

```diff
+ import { createClient } from "@/lib/supabase/server";

  export async function POST(req: NextRequest) {
    try {
+     const supabase = await createClient();
+     const { data: { user } } = await supabase.auth.getUser();
+     if (!user) {
+       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+     }
+
      // ... rest of handler
    }
  }
```

In `wallet/route.ts`, the redundant inner `createClient() / getUser()` block (which only set the `userId` on the inserted DB record) was also removed — the outer `supabase` and `user` are reused instead.

## Impact

- **Security:** Unauthenticated Circle SDK abuse is no longer possible.
- **Consistency:** Both handlers now match the auth pattern used by every other route in this codebase.
- **Risk:** Low — no behavior change for authenticated users; unauthenticated callers now get a proper 401.