### PR TITLE
fix: add ARC_TESTNET_RPC_KEY to .env.example and remove hardcoded fallback

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,3 +6,6 @@ SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
 # Circle
 CIRCLE_API_KEY=your-circle-api-key
 CIRCLE_ENTITY_SECRET=your-circle-entity-secret
+
+# Arc Testnet
+ARC_TESTNET_RPC_KEY=your-arc-testnet-rpc-key

--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ CIRCLE_ENTITY_SECRET=your-circle-entity-secret
 | `SUPABASE_SERVICE_ROLE_KEY` | Server-side | Supabase service role key for admin operations. |
 | `CIRCLE_API_KEY` | Server-side | Circle API key for wallet operations. |
 | `CIRCLE_ENTITY_SECRET` | Server-side | Circle entity secret for signing transactions. |
+| `ARC_TESTNET_RPC_KEY` | Server-side | Arc Testnet RPC key. Get from https://rpc.testnet.arc.network |
 
 ## User Accounts
 

--- a/lib/circle/gateway-sdk.ts
+++ b/lib/circle/gateway-sdk.ts
@@ -39,7 +39,10 @@ import {
 export const GATEWAY_WALLET_ADDRESS = "0x0077777d7EBA4688BDeF3E311b846F25870A19B9";
 export const GATEWAY_MINTER_ADDRESS = "0x0022222ABE238Cc2C7Bb1f21003F0a260052475B";
 
-const arcRpcKey = process.env.ARC_TESTNET_RPC_KEY || 'c0ca2582063a5bbd5db2f98c139775e982b16919';
+const arcRpcKey = process.env.ARC_TESTNET_RPC_KEY;
+if (!arcRpcKey) {
+  console.warn('[arc-fintech] ARC_TESTNET_RPC_KEY is not set. Add it to .env.local. See .env.example.');
+}
 
 export const arcTestnet = {
   id: 5042002,


### PR DESCRIPTION
## Problem

`lib/circle/gateway-sdk.ts` line 42 contains a hardcoded fallback RPC key:

```typescript
const arcRpcKey = process.env.ARC_TESTNET_RPC_KEY || 'c0ca2582063a5bbd5db2f98c139775e982b16919';
```

This key is not documented in `.env.example` or `README.md`, so developers who clone the repo have no indication that this variable exists or that they should set it. The hardcoded fallback also means the key is exposed in the public repository.

## Fix

- Removed the hardcoded fallback value
- Added a `console.warn` when `ARC_TESTNET_RPC_KEY` is not set
- Added `ARC_TESTNET_RPC_KEY` to `.env.example`
- Added `ARC_TESTNET_RPC_KEY` to the Environment Variables table in `README.md`

## Changes

- `.env.example` — added `ARC_TESTNET_RPC_KEY=your-arc-testnet-rpc-key`
- `lib/circle/gateway-sdk.ts` — removed hardcoded fallback, added warning
- `README.md` — documented the variable in the env vars table