### PR TITLE
chore(ci): bump GitHub Actions to Node 24

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -12,7 +12,7 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       with:
         ref: "traffic"
     
@@ -24,7 +24,7 @@ jobs:
      
     # Commits files to repository
     - name: Commit changes
-      uses: EndBug/add-and-commit@v4
+      uses: EndBug/add-and-commit@290ea2c423ad77ca9c62ae0f5b224379612c0321 # v10.0.0
       with:
         author_name: Traffic Bot
         message: "GitHub traffic"


### PR DESCRIPTION
## Summary

Bulk SHA-pin update of GitHub Actions to their latest Node-24-compatible release. Pre-emptive migration ahead of GitHub Actions runner Node 20 removal in Fall 2026.

## Actions bumped

- `actions/checkout@v2` → `df4cb1c0…` (v6.0.3)
- `EndBug/add-and-commit@v4` → `290ea2c4…` (v10.0.0)

## Verification

Every emitted SHA was verified via `gh api /repos/<owner>/<repo>/commits/<sha>` before commit.

## Background

Node 20 is being removed from GitHub Actions runners in Fall 2026 (see [GitHub changelog](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)). This PR pre-emptively bumps every pinned third-party action to its first Node-24-compatible release so the workflows keep running on the new runner default.